### PR TITLE
perf: disabled revalidate to stop the server being called on every colour change

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -6,6 +6,7 @@ import {
 	ScrollRestoration,
 	json,
 	useLoaderData,
+	ShouldRevalidateFunction,
 } from '@remix-run/react';
 import { useSWEffect } from '@remix-pwa/sw';
 
@@ -162,6 +163,10 @@ export const loader = async ({
 		levels,
 		GOOGLE_FONTS_APIKEY,
 	});
+};
+
+export const shouldRevalidate: ShouldRevalidateFunction = () => {
+	return false;
 };
 
 export default function App() {


### PR DESCRIPTION
**✨ What kind of change does this PR introduce?**

It's a performance improvement that stops the server being called for every single colour change

**🧪 Did you add tests for your changes?**

No, not needed.

**📝 Summary**

Server requests were being made on every colour change that could cause problems on slow connections and was using the server allowance up rapidly
https://github.com/Pushedskydiver/Colour-Contrast-Checker/issues/136

**💥 Does this PR introduce a breaking change?**

Yes, clicking back after changing colours will no longer change the colour back to what it was before, a refresh will be needed. A more permanent solution is needed.

**🧑‍💻 Other information**

N/A
